### PR TITLE
Modifying /prowler-studio/mcp_server/Dockerfile

### DIFF
--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -9,13 +9,10 @@ RUN addgroup -g 1000 prowler_studio && \
 
 USER prowler_studio
 
-COPY --chown=prowler_studio:prowler_studio ./core /home/prowler_studio/prowler_studio/core
-COPY --chown=prowler_studio:prowler_studio ./mcp_server /home/prowler_studio/prowler_studio/mcp_server
-COPY --chown=prowler_studio:prowler_studio ./pyproject.toml /home/prowler_studio/prowler_studio/pyproject.toml
-COPY --chown=prowler_studio:prowler_studio ./uv.lock /home/prowler_studio/prowler_studio/uv.lock
+COPY --chown=prowler_studio:prowler_studio ./ /home/prowler_studio/prowler_studio
 
 WORKDIR /home/prowler_studio/prowler_studio/mcp_server
 
-RUN uv sync --frozen --no-dev --no-editable --no-cache && rm -rf /home/prowler_studio/prowler_studio/core/
+RUN uv sync --frozen --no-dev --no-editable --no-cache
 
 ENTRYPOINT ["uvx", "/home/prowler_studio/prowler_studio/mcp_server/"]


### PR DESCRIPTION
When following the instructions in prowler-studio/docs/mcp_server.md in the AWS EC2 environment, the following error occurred.

```
$ docker run --rm -i -e GOOGLE_API_KEY=[Google API Key] prowler-studio-mcp-server
  × Failed to build `prowler-studio-mcp-server @
  │ file:///home/prowler_studio/prowler_studio/mcp_server`
  ├─▶ Failed to parse entry: `prowler-studio-core`
  ╰─▶ `prowler-studio-core` references a workspace in `tool.uv.sources` (e.g.,
      `prowler-studio-core = { workspace = true }`), but is not a workspace
      member
```

To resolve this, we modified the Dockerfile as follows.

```
FROM ghcr.io/astral-sh/uv:python3.13-alpine

LABEL maintainer="https://github.com/prowler-cloud"

RUN apk add --no-cache cargo

RUN addgroup -g 1000 prowler_studio && \
    adduser -D -u 1000 -G prowler_studio prowler_studio

USER prowler_studio

COPY --chown=prowler_studio:prowler_studio ./ /home/prowler_studio/prowler_studio

WORKDIR /home/prowler_studio/prowler_studio/mcp_server

RUN uv sync --frozen --no-dev --no-editable --no-cache

ENTRYPOINT [“uvx”, “/home/prowler_studio/prowler_studio/mcp_server/”]
```

I confirmed that it works normally after the modification.

```
$ docker run --rm -i -e GOOGLE_API_KEY=[Google API Key] prowler-studio-mcp-server
Building prowler-studio-core @ file:///home/prowler_studio/prowler_studio/core      Building prowler-studio-mcp-server @ file:///home/prowler_studio/prowler_studio/mcp_server
Downloading google-api-python-client (13.3MiB)
Downloading google-ai-generativelanguage (1.3MiB)...

```