### PR TITLE
feat(workflow): add git worktree support for parallel ticket work

### DIFF
--- a/src/agents/pr_creation/prompts/pr_description.jinja
+++ b/src/agents/pr_creation/prompts/pr_description.jinja
@@ -115,7 +115,7 @@ This check detects security misconfigurations.
 Create the PR using `gh pr create`:
 
 ```bash
-gh pr create --title "feat({{ check_provider }}): add {{ check_name }} security check" --body "$(cat <<'EOF'
+gh pr create --draft --title "feat({{ check_provider }}): add {{ check_name }} security check" --body "$(cat <<'EOF'
 ### Context
 
 [Write 2-3 sentences explaining the security risk this check addresses.

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -15,7 +15,16 @@ from agents.implementation.agent import ChecKreatorAgent
 from agents.pr_creation.agent import PRCreationAgent
 from agents.review.agent import ReviewAgent
 from agents.testing.agent import TestingAgent
-from tools.git import generate_branch_name, prepare_repo_for_work, rename_branch
+from tools.git import (
+    create_worktree,
+    ensure_main_repo_exists,
+    generate_branch_name,
+    get_worktree_name,
+    prepare_repo_for_work,
+    remove_worktree,
+    rename_branch,
+    update_main_repo,
+)
 from tools.jira import parse_jira_url
 from tools.jira_client import JiraClient, JiraClientError, JiraTicketContent
 from tools.prowler import ProwlerToolError, install_prowler_dependencies
@@ -70,6 +79,20 @@ def create_check(
             help="Path to the working directory (default: ./working)",
         ),
     ] = Path("./working"),
+    no_worktree: Annotated[
+        bool,
+        typer.Option(
+            "--no-worktree",
+            help="Legacy mode: work directly on main clone instead of using worktrees",
+        ),
+    ] = False,
+    cleanup_worktree: Annotated[
+        bool,
+        typer.Option(
+            "--cleanup-worktree",
+            help="Remove worktree after successful PR creation",
+        ),
+    ] = False,
 ) -> None:
     """
     Create a Prowler check from a markdown ticket or Jira URL.
@@ -136,34 +159,46 @@ def create_check(
             raise typer.Exit(code=1) from e
 
     # Clone/prepare Prowler repository
-    prowler_repo_path = working_dir / "prowler"
+    main_repo_path = working_dir / "prowler"
+    worktree_path: Path | None = None
+    main_repo: Repo | None = None
 
-    if prowler_repo_path.exists():
-        logging.warning(f"Using existing Prowler repository at {prowler_repo_path}")
-        try:
-            repo = Repo(prowler_repo_path)
-        except InvalidGitRepositoryError as e:
-            logging.error("Directory exists but is not a valid git repository")
-            raise typer.Exit(code=1) from e
-    else:
-        logging.info("[bold]Cloning Prowler repository...[/bold]")
-        try:
-            repo = Repo.clone_from(url=PROWLER_REPO_URL, to_path=prowler_repo_path)
-        except GitError as e:
-            logging.error(f"Git error: {e}")
-            raise typer.Exit(code=1) from e
+    try:
+        main_repo = ensure_main_repo_exists(working_dir, PROWLER_REPO_URL)
+    except InvalidGitRepositoryError as e:
+        logging.error("Directory exists but is not a valid git repository")
+        raise typer.Exit(code=1) from e
+    except GitError as e:
+        logging.error(f"Git error: {e}")
+        raise typer.Exit(code=1) from e
 
     # Determine branch name (use temp branch if not provided)
     temp_branch_name: str | None = None
+    current_timestamp = int(time.time())
     if branch_name is None:
-        temp_branch_name = f"feat/new-check-{int(time.time())}"
+        temp_branch_name = f"feat/new-check-{current_timestamp}"
         effective_branch = temp_branch_name
     else:
         effective_branch = branch_name
 
-    # Prepare branch
+    # Setup repository: worktree mode (default) or legacy mode
     logging.info("[bold]Preparing repository...[/bold]")
-    prepare_repo_for_work(repo, effective_branch)
+
+    if not no_worktree:
+        # Worktree mode: create isolated worktree for this work
+        update_main_repo(main_repo)
+        worktree_name = get_worktree_name(
+            jira_issue_key, ticket_file, current_timestamp
+        )
+        worktree_path = working_dir / "worktrees" / worktree_name
+        repo = create_worktree(main_repo, worktree_path, effective_branch)
+        prowler_repo_path = worktree_path
+        logging.info(f"[cyan]Worktree: {worktree_path}[/cyan]")
+    else:
+        # Legacy mode: work directly on main clone
+        prepare_repo_for_work(main_repo, effective_branch)
+        repo = main_repo
+        prowler_repo_path = main_repo_path
 
     # Setup AI skills for Claude (non-blocking on failure)
     skills_result = setup_prowler_skills(prowler_directory=prowler_repo_path)
@@ -336,6 +371,13 @@ def create_check(
             logging.info(f"  Branch: {final_branch_name}")
             logging.info(f"  PR: {pr_result.pr_url}")
             logging.info(f"  Commit: {pr_result.commit_sha[:8]}")
+
+            # Cleanup worktree if requested
+            if cleanup_worktree and not no_worktree and worktree_path and main_repo:
+                logging.info("[yellow]Cleaning up worktree...[/yellow]")
+                remove_worktree(main_repo, worktree_path)
+                logging.info("[green]✓ Worktree removed[/green]")
+
             logging.info("=" * 60)
             logging.info("WORKFLOW COMPLETE")
             logging.info("=" * 60)

--- a/src/tools/git.py
+++ b/src/tools/git.py
@@ -1,11 +1,154 @@
 """Git repository tools."""
 
+from pathlib import Path
+
 from git import Repo
 from git.exc import GitCommandError
 from rich import print
 
 # Constants
 DEFAULT_BRANCH: str = "master"
+
+
+def ensure_main_repo_exists(working_dir: Path, repo_url: str) -> Repo:
+    """
+    Clone repo if not exists, return Repo object.
+
+    Args:
+        working_dir: Working directory containing the repo
+        repo_url: Git URL to clone from
+
+    Returns:
+        Repo object for the main repository
+
+    Raises:
+        GitCommandError: If clone fails
+    """
+    repo_path = working_dir / "prowler"
+
+    if repo_path.exists():
+        print(f"[yellow]Using existing Prowler repository at {repo_path}[/yellow]")
+        return Repo(repo_path)
+    else:
+        print("[bold]Cloning Prowler repository...[/bold]")
+        return Repo.clone_from(url=repo_url, to_path=repo_path)
+
+
+def update_main_repo(repo: Repo, base_branch: str = DEFAULT_BRANCH) -> None:
+    """
+    Fetch and update main branch before creating worktree.
+
+    Args:
+        repo: The main Repo object
+        base_branch: Branch to update (default: master)
+    """
+    print(f"[yellow]Updating {base_branch} branch...[/yellow]")
+
+    # Fetch latest from origin
+    origin = repo.remotes.origin
+    origin.fetch()
+
+    # Update local base branch to match remote
+    repo.git.checkout(base_branch)
+    repo.git.pull("origin", base_branch)
+
+    print(f"[green]✓ Updated {base_branch} to latest[/green]")
+
+
+def create_worktree(
+    main_repo: Repo,
+    worktree_path: Path,
+    branch_name: str,
+    base_branch: str = DEFAULT_BRANCH,
+) -> Repo:
+    """
+    Create new worktree with a new branch from base.
+
+    Args:
+        main_repo: The main Repo object
+        worktree_path: Path where worktree will be created
+        branch_name: Name of the new branch to create
+        base_branch: Branch to base the new branch on (default: master)
+
+    Returns:
+        Repo object for the new worktree
+
+    Raises:
+        GitCommandError: If worktree creation fails
+    """
+    # Ensure parent directory exists
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"[yellow]Creating worktree at {worktree_path}...[/yellow]")
+
+    # Create worktree with new branch based on base_branch
+    main_repo.git.worktree("add", "-b", branch_name, str(worktree_path), base_branch)
+
+    print(f"[green]✓ Created worktree with branch '{branch_name}'[/green]")
+
+    return Repo(worktree_path)
+
+
+def remove_worktree(main_repo: Repo, worktree_path: Path) -> None:
+    """
+    Remove worktree and its branch.
+
+    Args:
+        main_repo: The main Repo object
+        worktree_path: Path to the worktree to remove
+    """
+    print(f"[yellow]Removing worktree at {worktree_path}...[/yellow]")
+
+    # Get the branch name before removing worktree
+    try:
+        worktree_repo = Repo(worktree_path)
+        branch_name = worktree_repo.active_branch.name
+    except Exception:
+        branch_name = None
+
+    # Remove the worktree
+    main_repo.git.worktree("remove", str(worktree_path), "--force")
+    print("[green]✓ Removed worktree[/green]")
+
+    # Optionally delete the branch if it exists
+    if branch_name:
+        try:
+            main_repo.git.branch("-D", branch_name)
+            print(f"[green]✓ Deleted branch '{branch_name}'[/green]")
+        except GitCommandError:
+            pass  # Branch may already be deleted or not exist
+
+
+def get_worktree_name(
+    ticket_key: str | None,
+    ticket_file: Path | None,
+    timestamp: int,
+) -> str:
+    """
+    Generate worktree directory name.
+
+    Returns name based on available info:
+    - With Jira: 'prowler-123-1706450000'
+    - With file: '<filename>-1706450000' (e.g., 's3-bucket-check-1706450000')
+    - Neither: 'new-check-1706450000'
+
+    Args:
+        ticket_key: Optional Jira ticket key (e.g., 'PROWLER-123')
+        ticket_file: Optional path to ticket file
+        timestamp: Unix timestamp
+
+    Returns:
+        Worktree directory name
+    """
+    if ticket_key:
+        # Convert PROWLER-123 to prowler-123
+        return f"{ticket_key.lower()}-{timestamp}"
+    elif ticket_file:
+        # Use filename without extension
+        filename = ticket_file.stem.replace("_", "-")
+        return f"{filename}-{timestamp}"
+    else:
+        return f"new-check-{timestamp}"
 
 
 def commit_changes(

--- a/src/tools/prowler.py
+++ b/src/tools/prowler.py
@@ -28,6 +28,7 @@ DEFAULT_WORKING_DIR: Path = Path("./working/prowler")
     input_schema={
         "provider": str,
         "check_name": str,
+        "prowler_directory": str,
     },
 )
 async def mkcheck(args: dict[str, Any]) -> dict[str, Any]:
@@ -41,6 +42,7 @@ async def mkcheck(args: dict[str, Any]) -> dict[str, Any]:
         args: Dictionary containing:
             - provider: Cloud provider (e.g., 'gcp', 'aws', 'azure')
             - check_name: Name of the check (without service prefix)
+            - prowler_directory: Path to the Prowler repository (optional, defaults to ./working/prowler)
 
     Returns:
         Dictionary with content and optional error status
@@ -49,7 +51,9 @@ async def mkcheck(args: dict[str, Any]) -> dict[str, Any]:
         # Extract parameters with explicit type hints
         provider: str = args["provider"]
         check_name: str = args["check_name"]
-        prowler_directory: Path = DEFAULT_WORKING_DIR
+        prowler_directory: Path = Path(
+            args.get("prowler_directory") or DEFAULT_WORKING_DIR
+        )
 
         # Build check folder path
         check_folder: Path = (


### PR DESCRIPTION
> [!IMPORTANT]
> **Dependency:** This PR depends on `new-product-v2` being merged first. Please merge #87 before this one.

## Summary

- Add git worktree support for isolated workspaces per ticket
- Enable parallel execution of multiple tickets without conflicts
- Add `--no-worktree` flag for legacy mode (direct clone)
- Add `--cleanup-worktree` flag to remove worktree after success
- Fix `mkcheck` tool to accept `prowler_directory` parameter
- PRs are now created as drafts by default for human validation

## Directory Structure (with worktrees)

```
working/
├── prowler/              # Main clone (shared git objects)
├── worktrees/            # All worktrees created here
│   ├── prowler-123-1706450000/
│   └── ...
└── logs/
```

## Test plan

- [x] Test worktree mode with Jira ticket
- [x] Test worktree mode with file ticket
- [ ] Test legacy mode (`--no-worktree`)
- [ ] Test cleanup mode (`--cleanup-worktree`)
- [x] Test parallel runs with multiple tickets