### PR TITLE
feat(logging): add DEBUG-level tool call logging for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,19 @@ This document outlines the coding standards and best practices for developing ag
 
 ## Architecture Principles
 
+### Base Agent Class
+
+All agents inherit from the `Agent` base class ([src/agents/base.py](src/agents/base.py)), which provides:
+
+- **`working_dir`**: Path to the working directory
+- **`config`**: Agent-specific configuration from kwargs
+- **`_process_agent_messages(client)`**: Shared method for processing Claude SDK responses
+  - Streams `TextBlock` content to console and logs
+  - Logs `ToolUseBlock` inputs at DEBUG level (`[TOOL CALL]`)
+  - Logs `ToolResultBlock` outputs at DEBUG level (`[TOOL RESULT]`)
+
+Agents must implement the abstract `run()` method.
+
 ### Single Responsibility Principle (SRP)
 
 Each method should have **one clear purpose**. If a method does multiple things, break it down.
@@ -94,8 +107,8 @@ class ChecKreatorAgent(Agent):
     def _load_fix_prompt(self, check_name: str, message: str) -> str: ...
     def _create_claude_options(self) -> ClaudeAgentOptions: ...
 
-    # Processing methods
-    async def _process_agent_messages(self, client: ClaudeSDKClient) -> None: ...
+    # Inherited from Agent base class:
+    # async def _process_agent_messages(self, client: ClaudeSDKClient) -> None: ...
 
     # Business logic methods
     def _discover_check_info(self) -> CheckDiscoveryResult: ...

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ prowler_studio/
 │   │   └── models.py            # Tool data models
 │   └── utils/                   # Utilities
 │       ├── prompts.py           # Prompt loading utilities
-│       └── logging.py           # Agent output logging
+│       └── logging.py           # Logging utilities (agent output + tool calls)
 └── pyproject.toml               # Project configuration
 ```
 
@@ -159,6 +159,27 @@ Key features:
 
 #### Jira Tools ([src/tools/jira.py](src/tools/jira.py))
 - `parse_jira_url()`: Parse Jira ticket URL into components (site_url, project_key, issue_key)
+
+### Logging & Observability
+
+All workflow runs are logged to timestamped files in the `logs/` directory.
+
+**Log Levels:**
+- **INFO** (console + file): Workflow progress, agent status, success/failure messages
+- **DEBUG** (file only): Agent text output, tool calls with inputs/outputs
+
+**DEBUG-level tool call logging** captures all Claude agent tool usage:
+```
+2025-02-02 10:30:45 | DEBUG    | [TOOL CALL] Read (id=tool_abc123)
+{
+  "file_path": "/path/to/file.py"
+}
+2025-02-02 10:30:46 | DEBUG    | [TOOL RESULT] Read [OK]
+1: def example():
+2:     return "hello"
+```
+
+This is useful for debugging agent behavior and understanding what tools were invoked during a workflow run.
 
 ### Main CLI Orchestration
 

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -2,7 +2,20 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import ClaudeSDKClient
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+
+from utils.logging import log_agent_output, log_tool_call
 
 
 class Agent(ABC):
@@ -23,6 +36,7 @@ class Agent(ABC):
         """
         self.working_dir = working_dir
         self.config = kwargs
+        self._tool_names_by_id: dict[str, str] = {}
 
     @abstractmethod
     async def run(self, **inputs: Any) -> Any:
@@ -38,3 +52,40 @@ class Agent(ABC):
         Raises:
             AgentError: If agent execution fails
         """
+
+    async def _process_agent_messages(self, client: "ClaudeSDKClient") -> None:
+        """
+        Process and stream messages from the Claude agent.
+
+        Handles TextBlock (prints + logs), ToolUseBlock (logs input at DEBUG),
+        and ToolResultBlock (logs output at DEBUG).
+
+        Args:
+            client: Claude SDK client instance
+        """
+        async for message in client.receive_response():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(block.text, end="", flush=True)
+                        log_agent_output(block.text)
+                    elif isinstance(block, ToolUseBlock):
+                        self._tool_names_by_id[block.id] = block.name
+                        log_tool_call(
+                            tool_name=block.name,
+                            tool_input=block.input,
+                            tool_use_id=block.id,
+                        )
+                    elif isinstance(block, ToolResultBlock):
+                        tool_name = self._tool_names_by_id.get(
+                            block.tool_use_id, "Unknown"
+                        )
+                        log_tool_call(
+                            tool_name=tool_name,
+                            tool_output=block.content,
+                            is_error=block.is_error or False,
+                            tool_use_id=block.tool_use_id,
+                        )
+            elif isinstance(message, ResultMessage):
+                print()
+                break

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -53,7 +53,9 @@ class Agent(ABC):
             AgentError: If agent execution fails
         """
 
-    async def _process_agent_messages(self, client: "ClaudeSDKClient") -> None:
+    async def _process_agent_messages(
+        self, client: "ClaudeSDKClient", *, capture_text: bool = False
+    ) -> str:
         """
         Process and stream messages from the Claude agent.
 
@@ -62,13 +64,22 @@ class Agent(ABC):
 
         Args:
             client: Claude SDK client instance
+            capture_text: If True, return captured text output
+
+        Returns:
+            Captured text if capture_text=True, empty string otherwise
         """
+        self._tool_names_by_id.clear()  # Reset for new conversation
+        captured: list[str] = []
+
         async for message in client.receive_response():
             if isinstance(message, AssistantMessage):
                 for block in message.content:
                     if isinstance(block, TextBlock):
                         print(block.text, end="", flush=True)
                         log_agent_output(block.text)
+                        if capture_text:
+                            captured.append(block.text)
                     elif isinstance(block, ToolUseBlock):
                         self._tool_names_by_id[block.id] = block.name
                         log_tool_call(
@@ -89,3 +100,5 @@ class Agent(ABC):
             elif isinstance(message, ResultMessage):
                 print()
                 break
+
+        return "".join(captured) if capture_text else ""

--- a/src/agents/compliance_mapping/agent.py
+++ b/src/agents/compliance_mapping/agent.py
@@ -11,16 +11,12 @@ if TYPE_CHECKING:
     from git import Repo
 
 from claude_agent_sdk import (
-    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
-    ResultMessage,
-    TextBlock,
 )
 
 from agents.base import Agent
 from agents.compliance_mapping.models import ComplianceMappingResult
-from utils.logging import log_agent_output
 from utils.prompts import load_prompt
 
 
@@ -123,19 +119,6 @@ class ComplianceMappingAgent(Agent):
             permission_mode="bypassPermissions",
             cwd=str(self.working_dir),
         )
-
-    async def _process_agent_messages(self, client: ClaudeSDKClient) -> None:
-        """Process and stream messages from the Claude agent."""
-        async for message in client.receive_response():
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        # Use builtin print for real-time streaming
-                        print(block.text, end="", flush=True)
-                        log_agent_output(block.text)
-            elif isinstance(message, ResultMessage):
-                print()  # Newline after streaming
-                break
 
     def _get_modified_compliance_files(self) -> set[str]:
         """Get the set of modified compliance JSON files."""

--- a/src/agents/implementation/agent.py
+++ b/src/agents/implementation/agent.py
@@ -12,11 +12,8 @@ if TYPE_CHECKING:
     from tools.models import CheckVerificationStatus
 
 from claude_agent_sdk import (
-    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
-    ResultMessage,
-    TextBlock,
     create_sdk_mcp_server,
 )
 
@@ -27,7 +24,6 @@ from agents.implementation.models import (
     CheckVerificationResult,
 )
 from tools.prowler import mkcheck, verify_check_loaded
-from utils.logging import log_agent_output
 from utils.prompts import load_prompt
 
 
@@ -165,24 +161,6 @@ class ChecKreatorAgent(Agent):
             permission_mode="bypassPermissions",
             cwd=str(self.working_dir),
         )
-
-    async def _process_agent_messages(self, client: ClaudeSDKClient) -> None:
-        """
-        Process and stream messages from the Claude agent.
-
-        Args:
-            client: Claude SDK client instance
-        """
-        async for message in client.receive_response():
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        # Use builtin print for real-time streaming
-                        print(block.text, end="", flush=True)
-                        log_agent_output(block.text)
-            elif isinstance(message, ResultMessage):
-                print()  # Newline after streaming
-                break
 
     def _discover_check_info(self) -> CheckDiscoveryResult:
         """

--- a/src/agents/pr_creation/agent.py
+++ b/src/agents/pr_creation/agent.py
@@ -11,19 +11,10 @@ from typing import TYPE_CHECKING, Any, ClassVar
 if TYPE_CHECKING:
     from git import Repo
 
-from claude_agent_sdk import (
-    AssistantMessage,
-    ClaudeAgentOptions,
-    ClaudeSDKClient,
-    ResultMessage,
-    TextBlock,
-    ToolResultBlock,
-    ToolUseBlock,
-)
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 
 from agents.base import Agent
 from agents.pr_creation.models import PRCreationResult
-from utils.logging import log_agent_output, log_tool_call
 from utils.prompts import load_prompt
 
 
@@ -76,8 +67,8 @@ class PRCreationAgent(Agent):
         async with ClaudeSDKClient(options=options) as client:
             logging.info("[yellow]Creating commit and pull request...[/yellow]")
             await client.query(pr_prompt)
-            response_text: str = await self._process_agent_messages_capture(
-                client=client
+            response_text: str = await self._process_agent_messages(
+                client, capture_text=True
             )
 
         # Extract PR information from response
@@ -131,38 +122,6 @@ class PRCreationAgent(Agent):
             permission_mode="bypassPermissions",
             cwd=str(self.working_dir),
         )
-
-    async def _process_agent_messages_capture(self, client: ClaudeSDKClient) -> str:
-        """Process agent messages, capture text output, and log tool calls."""
-        captured_text: list[str] = []
-        async for message in client.receive_response():
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        print(block.text, end="", flush=True)
-                        log_agent_output(block.text)
-                        captured_text.append(block.text)
-                    elif isinstance(block, ToolUseBlock):
-                        self._tool_names_by_id[block.id] = block.name
-                        log_tool_call(
-                            tool_name=block.name,
-                            tool_input=block.input,
-                            tool_use_id=block.id,
-                        )
-                    elif isinstance(block, ToolResultBlock):
-                        tool_name = self._tool_names_by_id.get(
-                            block.tool_use_id, "Unknown"
-                        )
-                        log_tool_call(
-                            tool_name=tool_name,
-                            tool_output=block.content,
-                            is_error=block.is_error or False,
-                            tool_use_id=block.tool_use_id,
-                        )
-            elif isinstance(message, ResultMessage):
-                print()
-                break
-        return "".join(captured_text)
 
     def _extract_pr_info(self, response_text: str) -> None:
         """Extract PR URL and number from response text."""

--- a/src/agents/pr_creation/agent.py
+++ b/src/agents/pr_creation/agent.py
@@ -17,11 +17,13 @@ from claude_agent_sdk import (
     ClaudeSDKClient,
     ResultMessage,
     TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
 )
 
 from agents.base import Agent
 from agents.pr_creation.models import PRCreationResult
-from utils.logging import log_agent_output
+from utils.logging import log_agent_output, log_tool_call
 from utils.prompts import load_prompt
 
 
@@ -131,18 +133,34 @@ class PRCreationAgent(Agent):
         )
 
     async def _process_agent_messages_capture(self, client: ClaudeSDKClient) -> str:
-        """Process agent messages and capture text output."""
+        """Process agent messages, capture text output, and log tool calls."""
         captured_text: list[str] = []
         async for message in client.receive_response():
             if isinstance(message, AssistantMessage):
                 for block in message.content:
                     if isinstance(block, TextBlock):
-                        # Use builtin print for real-time streaming
                         print(block.text, end="", flush=True)
                         log_agent_output(block.text)
                         captured_text.append(block.text)
+                    elif isinstance(block, ToolUseBlock):
+                        self._tool_names_by_id[block.id] = block.name
+                        log_tool_call(
+                            tool_name=block.name,
+                            tool_input=block.input,
+                            tool_use_id=block.id,
+                        )
+                    elif isinstance(block, ToolResultBlock):
+                        tool_name = self._tool_names_by_id.get(
+                            block.tool_use_id, "Unknown"
+                        )
+                        log_tool_call(
+                            tool_name=tool_name,
+                            tool_output=block.content,
+                            is_error=block.is_error or False,
+                            tool_use_id=block.tool_use_id,
+                        )
             elif isinstance(message, ResultMessage):
-                print()  # Newline after streaming
+                print()
                 break
         return "".join(captured_text)
 

--- a/src/agents/review/agent.py
+++ b/src/agents/review/agent.py
@@ -10,16 +10,12 @@ if TYPE_CHECKING:
     from git import Repo
 
 from claude_agent_sdk import (
-    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
-    ResultMessage,
-    TextBlock,
 )
 
 from agents.base import Agent
 from agents.review.models import ReviewResult
-from utils.logging import log_agent_output
 from utils.prompts import load_prompt
 
 
@@ -112,19 +108,6 @@ class ReviewAgent(Agent):
             permission_mode="bypassPermissions",
             cwd=str(self.working_dir),
         )
-
-    async def _process_agent_messages(self, client: ClaudeSDKClient) -> None:
-        """Process and stream messages from the Claude agent."""
-        async for message in client.receive_response():
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        # Use builtin print for real-time streaming
-                        print(block.text, end="", flush=True)
-                        log_agent_output(block.text)
-            elif isinstance(message, ResultMessage):
-                print()  # Newline after streaming
-                break
 
     def _check_modified_files(self) -> bool:
         """Check if there are any modified files related to the check."""

--- a/src/agents/testing/agent.py
+++ b/src/agents/testing/agent.py
@@ -10,17 +10,13 @@ if TYPE_CHECKING:
     from git import Repo
 
 from claude_agent_sdk import (
-    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
-    ResultMessage,
-    TextBlock,
 )
 
 from agents.base import Agent
 from agents.testing.models import TestingResult
 from tools.prowler import run_pytest
-from utils.logging import log_agent_output
 from utils.prompts import load_prompt
 
 
@@ -210,16 +206,3 @@ class TestingAgent(Agent):
             permission_mode="bypassPermissions",
             cwd=str(self.working_dir),
         )
-
-    async def _process_agent_messages(self, client: ClaudeSDKClient) -> None:
-        """Process and stream messages from the Claude agent."""
-        async for message in client.receive_response():
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        # Use builtin print for real-time streaming
-                        print(block.text, end="", flush=True)
-                        log_agent_output(block.text)
-            elif isinstance(message, ResultMessage):
-                print()  # Newline after streaming
-                break

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -60,6 +60,22 @@ def setup_logging(base_dir: Path, ticket: str | None = None) -> Path:
     return log_file
 
 
+def _emit_debug_log(msg: str) -> None:
+    """Emit a DEBUG-level log record to file only."""
+    if _file_handler is None:
+        return
+    record = logging.LogRecord(
+        name="tool",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+    _file_handler.emit(record)
+
+
 def log_agent_output(text: str) -> None:
     """
     Log agent output text to the log file only (not console).
@@ -74,16 +90,7 @@ def log_agent_output(text: str) -> None:
     if clean_text.strip():
         for line in clean_text.splitlines():
             if line.strip():
-                record = logging.LogRecord(
-                    name="agent",
-                    level=logging.DEBUG,
-                    pathname="",
-                    lineno=0,
-                    msg=f"[AGENT] {line}",
-                    args=(),
-                    exc_info=None,
-                )
-                _file_handler.emit(record)
+                _emit_debug_log(f"[AGENT] {line}")
 
 
 def _strip_rich_markup(text: str) -> str:
@@ -115,59 +122,21 @@ def log_tool_call(
 
     if tool_input is not None:
         # Log tool call with input
-        header = f"[TOOL CALL] {tool_name}{id_suffix}"
-        record = logging.LogRecord(
-            name="tool",
-            level=logging.DEBUG,
-            pathname="",
-            lineno=0,
-            msg=header,
-            args=(),
-            exc_info=None,
-        )
-        _file_handler.emit(record)
+        _emit_debug_log(f"[TOOL CALL] {tool_name}{id_suffix}")
 
         # Log the input as formatted JSON
         try:
             input_json = json.dumps(tool_input, indent=2)
             for line in input_json.splitlines():
-                record = logging.LogRecord(
-                    name="tool",
-                    level=logging.DEBUG,
-                    pathname="",
-                    lineno=0,
-                    msg=line,
-                    args=(),
-                    exc_info=None,
-                )
-                _file_handler.emit(record)
+                _emit_debug_log(line)
         except (TypeError, ValueError):
             # Fallback if JSON serialization fails
-            record = logging.LogRecord(
-                name="tool",
-                level=logging.DEBUG,
-                pathname="",
-                lineno=0,
-                msg=str(tool_input),
-                args=(),
-                exc_info=None,
-            )
-            _file_handler.emit(record)
+            _emit_debug_log(str(tool_input))
 
     elif tool_output is not None:
         # Log tool result
         status = "ERROR" if is_error else "OK"
-        header = f"[TOOL RESULT] {tool_name} [{status}]"
-        record = logging.LogRecord(
-            name="tool",
-            level=logging.DEBUG,
-            pathname="",
-            lineno=0,
-            msg=header,
-            args=(),
-            exc_info=None,
-        )
-        _file_handler.emit(record)
+        _emit_debug_log(f"[TOOL RESULT] {tool_name} [{status}]")
 
         # Log the output (truncated if too long)
         output_str = _format_tool_output(tool_output)
@@ -180,16 +149,7 @@ def log_tool_call(
             ]
 
         for line in lines:
-            record = logging.LogRecord(
-                name="tool",
-                level=logging.DEBUG,
-                pathname="",
-                lineno=0,
-                msg=line,
-                args=(),
-                exc_info=None,
-            )
-            _file_handler.emit(record)
+            _emit_debug_log(line)
 
 
 def _format_tool_output(output: str | list[dict[str, Any]]) -> str:

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from datetime import datetime
 from pathlib import Path  # noqa: TC003 (used at runtime for path operations)
+from typing import Any
 
 from rich.logging import RichHandler
 
@@ -87,3 +89,114 @@ def log_agent_output(text: str) -> None:
 def _strip_rich_markup(text: str) -> str:
     """Strip Rich console markup from text."""
     return re.sub(r"\[/?[^\]]+\]", "", text)
+
+
+def log_tool_call(
+    tool_name: str | None,
+    tool_input: dict[str, Any] | None = None,
+    tool_output: str | list[dict[str, Any]] | None = None,
+    is_error: bool = False,
+    tool_use_id: str | None = None,
+) -> None:
+    """
+    Log tool call information to the log file only (not console).
+
+    Args:
+        tool_name: Name of the tool being called
+        tool_input: Input parameters for the tool (for TOOL CALL)
+        tool_output: Output from the tool (for TOOL RESULT)
+        is_error: Whether the tool result was an error
+        tool_use_id: Unique ID for correlating calls and results
+    """
+    if _file_handler is None:
+        return
+
+    id_suffix = f" (id={tool_use_id})" if tool_use_id else ""
+
+    if tool_input is not None:
+        # Log tool call with input
+        header = f"[TOOL CALL] {tool_name}{id_suffix}"
+        record = logging.LogRecord(
+            name="tool",
+            level=logging.DEBUG,
+            pathname="",
+            lineno=0,
+            msg=header,
+            args=(),
+            exc_info=None,
+        )
+        _file_handler.emit(record)
+
+        # Log the input as formatted JSON
+        try:
+            input_json = json.dumps(tool_input, indent=2)
+            for line in input_json.splitlines():
+                record = logging.LogRecord(
+                    name="tool",
+                    level=logging.DEBUG,
+                    pathname="",
+                    lineno=0,
+                    msg=line,
+                    args=(),
+                    exc_info=None,
+                )
+                _file_handler.emit(record)
+        except (TypeError, ValueError):
+            # Fallback if JSON serialization fails
+            record = logging.LogRecord(
+                name="tool",
+                level=logging.DEBUG,
+                pathname="",
+                lineno=0,
+                msg=str(tool_input),
+                args=(),
+                exc_info=None,
+            )
+            _file_handler.emit(record)
+
+    elif tool_output is not None:
+        # Log tool result
+        status = "ERROR" if is_error else "OK"
+        header = f"[TOOL RESULT] {tool_name} [{status}]"
+        record = logging.LogRecord(
+            name="tool",
+            level=logging.DEBUG,
+            pathname="",
+            lineno=0,
+            msg=header,
+            args=(),
+            exc_info=None,
+        )
+        _file_handler.emit(record)
+
+        # Log the output (truncated if too long)
+        output_str = _format_tool_output(tool_output)
+        max_lines = 50
+        lines = output_str.splitlines()
+        if len(lines) > max_lines:
+            lines = [
+                *lines[:max_lines],
+                f"... (truncated, {len(lines) - max_lines} more lines)",
+            ]
+
+        for line in lines:
+            record = logging.LogRecord(
+                name="tool",
+                level=logging.DEBUG,
+                pathname="",
+                lineno=0,
+                msg=line,
+                args=(),
+                exc_info=None,
+            )
+            _file_handler.emit(record)
+
+
+def _format_tool_output(output: str | list[dict[str, Any]]) -> str:
+    """Format tool output for logging."""
+    if isinstance(output, str):
+        return output
+    try:
+        return json.dumps(output, indent=2)
+    except (TypeError, ValueError):
+        return str(output)


### PR DESCRIPTION
## Summary

- Add `log_tool_call()` function to log tool names, inputs, and outputs at DEBUG level to the log file
- Move `_process_agent_messages()` to the base `Agent` class to eliminate duplication across 5 agents
- Log `[TOOL CALL]` with JSON-formatted input parameters
- Log `[TOOL RESULT]` with OK/ERROR status and truncated output (max 50 lines)
- Track tool names by ID for correlating calls with results

## Stack

This PR is stacked on #90 (`optional-PR-creation`). Please merge that first.

## Test plan

- [ ] Run the workflow with a test ticket
- [ ] Check the log file in `logs/` directory
- [ ] Verify DEBUG entries show `[TOOL CALL]` and `[TOOL RESULT]` with inputs/outputs
- [ ] Verify existing INFO-level logs and console output unchanged